### PR TITLE
Do not attemt to open the default folder

### DIFF
--- a/src/main/java/com/github/airblader/imap/catalog/ImapCatalog.java
+++ b/src/main/java/com/github/airblader/imap/catalog/ImapCatalog.java
@@ -116,9 +116,6 @@ public class ImapCatalog implements Catalog {
       throws DatabaseNotExistException, CatalogException {
     try {
       var defaultFolder = store.getDefaultFolder();
-      if (!defaultFolder.isOpen()) {
-        defaultFolder.open(Folder.READ_ONLY);
-      }
 
       return Arrays.stream(defaultFolder.list("*"))
           .filter(


### PR DESCRIPTION
The default folder might not be marked to contain messages, which
can make the call to #open fail. For listing folders the folder
actually doesn't need to be opened anyway.